### PR TITLE
Upgrading manifest to version 3

### DIFF
--- a/public/background-wrapper.js
+++ b/public/background-wrapper.js
@@ -1,0 +1,3 @@
+//Background wrapper to import the main background script
+//Needed for the manifest.json v3 upgrade
+importScripts("background.js");

--- a/public/background.js
+++ b/public/background.js
@@ -194,7 +194,7 @@ const checkLoginSession = async (tab) => {
   }
 }
 
-chrome.browserAction.onClicked.addListener(async (tab) => {
+chrome.action.onClicked.addListener(async (tab) => {
   chrome.tabs.sendMessage(tab.id, { run: 'LOAD_APP', type: 'LOADER_MAIN' });
   await checkLoginData(tab);
 });

--- a/public/content.js
+++ b/public/content.js
@@ -10,7 +10,6 @@ if(window.location.href.startsWith('https://slate.host')) {
         id: id 
       });
     });
-
   }
   //TODO: Have the extension change the 'download chrome extension' button
 }
@@ -78,9 +77,7 @@ function main(props) {
       .then((response) => response.text())
       .then((html) => {
         const styleStashHTML = html.replace(/\/static\//g, `${extensionOrigin}/static/`);
-        console.log('html', html)
-        console.log('styleStashHTML', styleStashHTML)
-           $(styleStashHTML).prependTo('body');
+        $(styleStashHTML).prependTo('body');
       })
       .catch((error) => {
         console.warn(error);

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,21 +1,20 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Slate Web Extension",
-  "description": "Manage your history, bookmarks and downloads",
-  "version": "1.0.0",
+  "description": "Easily save any link to your Slate account.",
+  "version": "3",
   "homepage_url": "https://slate.host",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "icon128.png",
     "default_title": "Slate Web Extension"
   },
   "background": {
-    "scripts": ["./jquery.js", "./background.js"],
-    "persistent": true
+    "service_worker": "background-wrapper.js"
   },
   "content_scripts": [{
     "matches": ["<all_urls>"],
@@ -27,18 +26,12 @@
     "run_at": "document_idle"
   }],
   "permissions": [
-    "activeTab", 
     "tabs",
-    "bookmarks",
-    "history",
-    "chrome://favicon/*",
-    "storage",
-    "downloads",
     "contextMenus",
-    "commands",
     "cookies",
-    "https://slate.host/*"
+    "commands"
   ],
+  "host_permissions": ["https://slate.host/"],
   "commands": {
     "open-app": {
       "suggested_key": {
@@ -62,12 +55,19 @@
       "description": "Direct save"
     }
   },
-  "content_security_policy": "script-src 'self' https://fonts.googleapis.com; object-src 'self';",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
   "web_accessible_resources": [
-    "index.html",
-    "/static/*",
-    "/fonts/*",
-    "Inter-Regular.ttf",
-    "../fonts/*"
+    {
+      "resources": [ 
+        "index.html",
+        "/static/*",
+        "/fonts/*",
+        "Inter-Regular.ttf",
+        "../fonts/*" 
+      ],
+      "matches": ["<all_urls>"]
+    }
   ]
 }


### PR DESCRIPTION
Required some changes to match the new manifest.json version:
- background scripts are replaced by service workers and a background wrapper to import the previous background scripts
- new json structure for web accessible resources and content scripts
- removed unused permissions
- changed browserAction api's to just action